### PR TITLE
Handles Errors A Little Better

### DIFF
--- a/test/data_schema_test.exs
+++ b/test/data_schema_test.exs
@@ -326,7 +326,11 @@ defmodule DataSchemaTest do
 
       blog = DataSchema.to_struct(input, BlagPost)
 
-      assert blog == {:error, %DataSchema.Errors{errors: [post_datetime: :invalid_format]}}
+      assert blog ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [post_datetime: %DataSchema.Errors{errors: [date: :invalid_format]}]
+                }}
     end
 
     defmodule FieldError do
@@ -339,7 +343,7 @@ defmodule DataSchemaTest do
 
       blog = DataSchema.to_struct(input, FieldError)
 
-      assert blog == :error
+      assert blog == {:error, %DataSchema.Errors{errors: [thing: "There was an error!"]}}
     end
 
     defmodule Has do
@@ -396,7 +400,7 @@ defmodule DataSchemaTest do
     test "errors on :list_of" do
       input = %{"thing" => [%{}]}
       blog = DataSchema.to_struct(input, ListOfError)
-      assert blog == :error
+      assert blog == {:error, %DataSchema.Errors{errors: [thing: "There was an error!"]}}
     end
 
     defmodule Many do

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -1,0 +1,136 @@
+defmodule DataSchema.ErrorsTest do
+  use ExUnit.Case, async: true
+
+  defmodule Author do
+    import DataSchema, only: [data_schema: 1]
+    data_schema(field: {:name, "name", fn _ -> :error end})
+  end
+
+  defmodule Comment do
+    import DataSchema, only: [data_schema: 1]
+    data_schema(has_one: {:author, "author", Author})
+  end
+
+  defmodule BlagPost do
+    import DataSchema, only: [data_schema: 1]
+
+    data_schema(
+      field: {:content, "content", &{:ok, to_string(&1)}},
+      has_many: {:comments, "comments", Comment}
+    )
+  end
+
+  test "has_many has_one" do
+    input = %{
+      "content" => "This is a blog post",
+      "comments" => [
+        %{"author" => %{"name" => "Ted"}},
+        %{"author" => %{"name" => "Danson"}}
+      ]
+    }
+
+    assert DataSchema.to_struct(input, BlagPost) ==
+             {
+               :error,
+               %DataSchema.Errors{
+                 errors: [
+                   comments: %DataSchema.Errors{
+                     errors: [author: %DataSchema.Errors{errors: [name: "There was an error!"]}]
+                   }
+                 ]
+               }
+             }
+  end
+
+  describe "runtime schema" do
+    test "" do
+    end
+  end
+
+  test "has_many" do
+    defmodule Cheeese do
+      require DataSchema
+
+      DataSchema.data_schema(field: {:mouldy?, "mouldy", fn _ -> :error end})
+    end
+
+    defmodule Saladd do
+      require DataSchema
+
+      DataSchema.data_schema(
+        field: {:name, "name", &{:ok, &1}},
+        has_many: {:cheese_slices, "cheese", Cheeese}
+      )
+    end
+
+    input = %{
+      "name" => "ted",
+      "cheese" => [%{"mouldy" => 1}]
+    }
+
+    assert DataSchema.to_struct(input, Saladd) ==
+             {:error,
+              %DataSchema.Errors{
+                errors: [
+                  cheese_slices: %DataSchema.Errors{errors: [mouldy?: "There was an error!"]}
+                ]
+              }}
+  end
+
+  describe "aggregate" do
+    test "default error" do
+      defmodule FieldEr do
+        import DataSchema, only: [data_schema: 1]
+        data_schema(field: {:foo, "foo", fn _ -> :error end})
+      end
+
+      defmodule AggErr do
+        import DataSchema, only: [data_schema: 1]
+        data_schema(aggregate: {:agg, FieldEr, fn x -> {:ok, x} end})
+      end
+
+      input = %{"foo" => 1}
+
+      assert DataSchema.to_struct(input, AggErr) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [agg: %DataSchema.Errors{errors: [foo: "There was an error!"]}]
+                }}
+    end
+
+    test "named error" do
+      defmodule FieldErr do
+        import DataSchema, only: [data_schema: 1]
+        data_schema(field: {:foo, "foo", fn _ -> {:error, "nope"} end})
+      end
+
+      defmodule AggEr do
+        import DataSchema, only: [data_schema: 1]
+        data_schema(aggregate: {:agg, FieldErr, fn x -> {:ok, x} end})
+      end
+
+      input = %{"foo" => 1}
+
+      assert DataSchema.to_struct(input, AggEr) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [agg: %DataSchema.Errors{errors: [foo: "nope"]}]
+                }}
+    end
+  end
+
+  test "list_of" do
+    defmodule Thing do
+      defstruct [:things]
+    end
+
+    schema = [
+      list_of: {:things, "things", fn _ -> :error end}
+    ]
+
+    input = %{"things" => [%{"thing" => 1}, %{"thing" => 1}]}
+
+    assert DataSchema.to_struct(input, Thing, schema, DataSchema.MapAccessor) ==
+             {:error, %DataSchema.Errors{errors: [things: "There was an error!"]}}
+  end
+end


### PR DESCRIPTION
There is still room for iteration but this at least now returns a
(possibly nested) error so you can see the path to the problematic key.

Previously we did this just for non null errors but this rolls it out
for any cast fn that returns {:error, thing} | :error

We use a default error message if one isn't provided