### PR TITLE
Feature: empty_values option

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.12.3-otp-24
-erlang 24.0.6
+elixir 1.13.4-otp-24
+erlang 24.3.4

--- a/lib/data_schema.ex
+++ b/lib/data_schema.ex
@@ -582,11 +582,6 @@ defmodule DataSchema do
       {field_type, {field, paths, cast_fn, field_opts}}, struct ->
         nullable? = Keyword.get(field_opts, :optional?, false)
         process_field({field_type, {field, paths, cast_fn}}, struct, nullable?, accessor, data)
-
-      {_, {_, _, _}} = field, struct ->
-        # By default fields are not nullable.
-        nullable? = false
-        process_field(field, struct, nullable?, accessor, data)
     end)
     |> case do
       {:error, error_message} -> {:error, error_message}

--- a/lib/data_schema.ex
+++ b/lib/data_schema.ex
@@ -619,7 +619,7 @@ defmodule DataSchema do
     optional? = Keyword.get(opts, :optional?)
 
     if value in empty_values and not optional? do
-      {:error, :empty_required_value}
+      {:error, :empty_required_value, value}
     else
       {:ok, value}
     end
@@ -631,15 +631,16 @@ defmodule DataSchema do
          accessor,
          data
        ) do
-    with value <- accessor.field(data, path),
-         {:ok, value} <- validate_against_empty_values(value, opts),
+    value = accessor.field(data, path)
+
+    with {:ok, value} <- validate_against_empty_values(value, opts),
          {:ok, casted_value} <- call_cast_fn(cast_fn, value),
          {:ok, casted_value} <-
            validate_against_empty_values(casted_value, opts) do
       {:cont, update_struct(struct, field, casted_value)}
     else
-      {:error, :empty_required_value} ->
-        {:halt, {:error, DataSchema.Errors.null_error(field)}}
+      {:error, :empty_required_value, value} ->
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       {:error, message} ->
         {:halt, {:error, DataSchema.Errors.new({field, message})}}
@@ -667,7 +668,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.null_error(field)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, value)}
@@ -697,7 +698,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.null_error(field)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, value)}
@@ -727,7 +728,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.null_error(field)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field, values)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, values)}
@@ -771,7 +772,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.null_error(field)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field, values)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, values)}
@@ -815,7 +816,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.null_error(field)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field, values)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, values)}

--- a/lib/data_schema.ex
+++ b/lib/data_schema.ex
@@ -619,7 +619,7 @@ defmodule DataSchema do
     optional? = Keyword.get(opts, :optional?)
 
     if value in empty_values and not optional? do
-      {:error, :empty_required_value, value}
+      {:error, :empty_required_value}
     else
       {:ok, value}
     end
@@ -639,7 +639,7 @@ defmodule DataSchema do
            validate_against_empty_values(casted_value, opts) do
       {:cont, update_struct(struct, field, casted_value)}
     else
-      {:error, :empty_required_value, value} ->
+      {:error, :empty_required_value} ->
         {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       {:error, message} ->
@@ -728,7 +728,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field, values)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, values)}
@@ -772,7 +772,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field, values)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, values)}
@@ -816,7 +816,7 @@ defmodule DataSchema do
 
     cond do
       considered_empty? and not optional? ->
-        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field, values)}}
+        {:halt, {:error, DataSchema.Errors.empty_required_value_error(field)}}
 
       considered_empty? and optional? ->
         {:cont, update_struct(struct, field, values)}

--- a/lib/data_schema.ex
+++ b/lib/data_schema.ex
@@ -605,19 +605,19 @@ defmodule DataSchema do
   end
 
   defp process_field(
-         {:field, {field, path, cast_fn, %{optional?: nullable?}}},
+         {:field, {field, path, cast_fn, %{optional?: optional?}}},
          struct,
          accessor,
          data
        ) do
-    case {accessor.field(data, path), nullable?} do
+    case {accessor.field(data, path), optional?} do
       {nil, false} ->
         {:halt, {:error, DataSchema.Errors.null_error(field)}}
 
       {value, _} ->
         case call_cast_fn(cast_fn, value) do
           {:ok, nil} ->
-            if nullable? do
+            if optional? do
               {:cont, update_struct(struct, field, nil)}
             else
               # Instead of halt we would have to
@@ -640,14 +640,14 @@ defmodule DataSchema do
   end
 
   defp process_field(
-         {:has_one, {field, path, {cast_module, inline_fields}, %{optional?: nullable?}}},
+         {:has_one, {field, path, {cast_module, inline_fields}, %{optional?: optional?}}},
          struct,
          accessor,
          data
        ) do
     case accessor.has_one(data, path) do
       nil ->
-        if nullable? do
+        if optional? do
           {:cont, update_struct(struct, field, nil)}
         else
           {:halt, {:error, DataSchema.Errors.null_error(field)}}
@@ -664,14 +664,14 @@ defmodule DataSchema do
   end
 
   defp process_field(
-         {:has_one, {field, path, cast_module, %{optional?: nullable?}}},
+         {:has_one, {field, path, cast_module, %{optional?: optional?}}},
          struct,
          accessor,
          data
        ) do
     case accessor.has_one(data, path) do
       nil ->
-        if nullable? do
+        if optional? do
           {:cont, update_struct(struct, field, nil)}
         else
           {:halt, {:error, DataSchema.Errors.null_error(field)}}
@@ -688,14 +688,14 @@ defmodule DataSchema do
   end
 
   defp process_field(
-         {:has_many, {field, path, {cast_module, inline_fields}, %{optional?: nullable?}}},
+         {:has_many, {field, path, {cast_module, inline_fields}, %{optional?: optional?}}},
          struct,
          accessor,
          data
        ) do
     case accessor.has_many(data, path) do
       nil ->
-        if nullable? do
+        if optional? do
           {:cont, update_struct(struct, field, nil)}
         else
           {:halt, {:error, DataSchema.Errors.null_error(field)}}
@@ -726,14 +726,14 @@ defmodule DataSchema do
   end
 
   defp process_field(
-         {:has_many, {field, path, cast_module, %{optional?: nullable?}}},
+         {:has_many, {field, path, cast_module, %{optional?: optional?}}},
          struct,
          accessor,
          data
        ) do
     case accessor.has_many(data, path) do
       nil ->
-        if nullable? do
+        if optional? do
           {:cont, update_struct(struct, field, nil)}
         else
           {:halt, {:error, DataSchema.Errors.null_error(field)}}
@@ -760,14 +760,14 @@ defmodule DataSchema do
   end
 
   defp process_field(
-         {:list_of, {field, path, cast_module, %{optional?: nullable?}}},
+         {:list_of, {field, path, cast_module, %{optional?: optional?}}},
          struct,
          accessor,
          data
        ) do
     case accessor.list_of(data, path) do
       nil ->
-        if nullable? do
+        if optional? do
           {:cont, update_struct(struct, field, nil)}
         else
           {:halt, {:error, DataSchema.Errors.null_error(field)}}
@@ -778,7 +778,7 @@ defmodule DataSchema do
         |> Enum.reduce_while([], fn datum, acc ->
           case call_cast_fn(cast_module, datum) do
             {:ok, nil} ->
-              if nullable? do
+              if optional? do
                 # Do we add nil or do we remove them? a list of nils seeeeems bad. But is it
                 # better to not remove information...?
                 {:cont, [nil | acc]}

--- a/lib/data_schema.ex
+++ b/lib/data_schema.ex
@@ -735,13 +735,13 @@ defmodule DataSchema do
 
       true ->
         values
-        |> Enum.reduce_while([], fn datum, acc ->
+        |> Enum.reduce_while([], fn value, acc ->
           # It's not possible for to_struct to return nil so we don't worry about it here.
           # Should we use the parent data accessor or should we require that the struct
           # defines one?
           # using the parent always doesn't work for compile time schemas. So that's hout
           # now doing one thing for both is either confusing or complicated.
-          case to_struct(datum, cast_module, inline_fields, accessor, []) do
+          case to_struct(value, cast_module, inline_fields, accessor, []) do
             {:ok, struct} -> {:cont, [struct | acc]}
             {:error, error} -> {:halt, {:error, DataSchema.Errors.new({field, error})}}
             :error -> {:halt, {:error, DataSchema.Errors.default_error(field)}}
@@ -779,13 +779,13 @@ defmodule DataSchema do
 
       true ->
         values
-        |> Enum.reduce_while([], fn datum, acc ->
+        |> Enum.reduce_while([], fn value, acc ->
           # It's not possible for to_struct to return nil so we don't worry about it here.
           # Should we use the parent data accessor or should we require that the struct
           # defines one?
           # using the parent always doesn't work for compile time schemas. So that's hout
           # now doing one thing for both is either confusing or complicated.
-          case to_struct(datum, cast_module) do
+          case to_struct(value, cast_module) do
             {:ok, struct} -> {:cont, [struct | acc]}
             {:error, error} -> {:halt, {:error, DataSchema.Errors.new({field, error})}}
             :error -> {:halt, {:error, DataSchema.Errors.default_error(field)}}
@@ -823,8 +823,8 @@ defmodule DataSchema do
 
       true ->
         values
-        |> Enum.reduce_while([], fn datum, acc ->
-          case call_cast_fn(cast_module, datum) do
+        |> Enum.reduce_while([], fn value, acc ->
+          case call_cast_fn(cast_module, value) do
             {:ok, nil} ->
               if optional? do
                 # Do we add nil or do we remove them? a list of nils seeeeems bad. But is it

--- a/lib/errors.ex
+++ b/lib/errors.ex
@@ -34,6 +34,15 @@ defmodule DataSchema.Errors do
     DataSchema.Errors.add_error(%DataSchema.Errors{}, {field, @non_null_error_message})
   end
 
+  @doc false
+  @empty_required_value_error_message "Field was required but value supplied is considered empty"
+  def empty_required_value_error(field) do
+    DataSchema.Errors.add_error(
+      %DataSchema.Errors{},
+      {field, @empty_required_value_error_message}
+    )
+  end
+
   @doc """
   Turns the DataSchema.Errors struct into a flattened error tuple of path to field and
   error message

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule DataSchema.MixProject do
     [
       app: :data_schema,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       package: package(),
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -25,7 +25,9 @@ defmodule DataSchema.AggregateTest do
                 %DataSchema.Errors{
                   errors: [
                     agg: %DataSchema.Errors{
-                      errors: [foo: "Field was marked as not null but was found to be null."]
+                      errors: [
+                        foo: "Field was required but value supplied is considered empty"
+                      ]
                     }
                   ]
                 }}

--- a/test/data_schema_test.exs
+++ b/test/data_schema_test.exs
@@ -71,6 +71,60 @@ defmodule DataSchemaTest do
                   ]
                 }}
     end
+
+    test "causes errors when making structs declared with values considered as empty (:list_of)" do
+      defmodule Something do
+        import DataSchema, only: [data_schema: 1]
+
+        data_schema(
+          field:
+            {:required_array, "required_array", fn v -> {:ok, v} end,
+             [optional?: false, empty_values: [[], nil]]}
+        )
+      end
+
+      assert DataSchema.to_struct(%{required_array: []}, Something) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    required_array: "Field was required but value supplied is considered empty"
+                  ]
+                }}
+
+      assert DataSchema.to_struct(%{required_array: nil}, Something) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    required_array: "Field was required but value supplied is considered empty"
+                  ]
+                }}
+    end
+
+    test "causes errors when making structs declared with values considered as empty (:has_many)" do
+      defmodule Commentary do
+        import DataSchema, only: [data_schema: 1]
+
+        data_schema(
+          has_many: {:comments, "comments", Comment, [optional?: false, empty_values: [[], nil]]}
+        )
+      end
+
+      assert DataSchema.to_struct(%{required_array: []}, Commentary) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    comments: "Field was required but value supplied is considered empty"
+                  ]
+                }}
+
+      assert DataSchema.to_struct(%{comments: nil}, Commentary) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    comments: "Field was required but value supplied is considered empty"
+                  ]
+                }}
+    end
   end
 
   describe "data_schema/1" do

--- a/test/data_schema_test.exs
+++ b/test/data_schema_test.exs
@@ -36,22 +36,22 @@ defmodule DataSchemaTest do
   end
 
   describe "empty_values option" do
-    defmodule Wallet do
-      import DataSchema, only: [data_schema: 1]
-
-      data_schema(
-        field:
-          {:account_number, "account_number", &DataSchemaTest.to_stringg/1,
-           [optional?: false, empty_values: ["", nil, :undefined]]}
-      )
-    end
-
     test "causes errors when making structs declared with values considered as empty (:field)" do
+      defmodule Wallet do
+        import DataSchema, only: [data_schema: 1]
+
+        data_schema(
+          field:
+            {:account_number, "account_number", &DataSchemaTest.to_stringg/1,
+             [optional?: false, empty_values: ["", nil, :undefined]]}
+        )
+      end
+
       assert DataSchema.to_struct(%{account_number: ""}, Wallet) ==
                {:error,
                 %DataSchema.Errors{
                   errors: [
-                    account_number: "Field was marked as not null but was found to be null."
+                    account_number: "Field was required but value supplied is considered empty"
                   ]
                 }}
 
@@ -59,7 +59,7 @@ defmodule DataSchemaTest do
                {:error,
                 %DataSchema.Errors{
                   errors: [
-                    account_number: "Field was marked as not null but was found to be null."
+                    account_number: "Field was required but value supplied is considered empty"
                   ]
                 }}
 
@@ -67,7 +67,7 @@ defmodule DataSchemaTest do
                {:error,
                 %DataSchema.Errors{
                   errors: [
-                    account_number: "Field was marked as not null but was found to be null."
+                    account_number: "Field was required but value supplied is considered empty"
                   ]
                 }}
     end
@@ -412,7 +412,9 @@ defmodule DataSchemaTest do
                  %DataSchema.Errors{
                    errors: [
                      thing: %DataSchema.Errors{
-                       errors: [integer: "Field was marked as not null but was found to be null."]
+                       errors: [
+                         integer: "Field was required but value supplied is considered empty"
+                       ]
                      }
                    ]
                  }
@@ -425,7 +427,9 @@ defmodule DataSchemaTest do
                {
                  :error,
                  %DataSchema.Errors{
-                   errors: [thing: "Field was marked as not null but was found to be null."]
+                   errors: [
+                     thing: "Field was required but value supplied is considered empty"
+                   ]
                  }
                }
     end
@@ -460,7 +464,9 @@ defmodule DataSchemaTest do
                 %DataSchema.Errors{
                   errors: [
                     things: %DataSchema.Errors{
-                      errors: [thing: "Field was marked as not null but was found to be null."]
+                      errors: [
+                        thing: "Field was required but value supplied is considered empty"
+                      ]
                     }
                   ]
                 }}

--- a/test/data_schema_test.exs
+++ b/test/data_schema_test.exs
@@ -35,6 +35,44 @@ defmodule DataSchemaTest do
     end
   end
 
+  describe "empty_values option" do
+    defmodule Wallet do
+      import DataSchema, only: [data_schema: 1]
+
+      data_schema(
+        field:
+        {:account_number, "account_number", &DataSchemaTest.to_stringg/1,
+         [optional?: false, empty_values: ["", nil, :undefined]]},
+      )
+    end
+
+    test "causes errors when making structs declared with values considered as empty (:field)" do
+      assert DataSchema.to_struct(%{account_number: ""}, Wallet) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    account_number: "Field was marked as not null but was found to be null."
+                  ]
+                }}
+
+      assert DataSchema.to_struct(%{account_number: nil}, Wallet) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    account_number: "Field was marked as not null but was found to be null."
+                  ]
+                }}
+
+      assert DataSchema.to_struct(%{account_number: :undefined}, Wallet) ==
+               {:error,
+                %DataSchema.Errors{
+                  errors: [
+                    account_number: "Field was marked as not null but was found to be null."
+                  ]
+                }}
+    end
+  end
+
   describe "data_schema/1" do
     test "The default MapAccessor is used when no accessor is provided" do
       input = %{

--- a/test/data_schema_test.exs
+++ b/test/data_schema_test.exs
@@ -41,8 +41,8 @@ defmodule DataSchemaTest do
 
       data_schema(
         field:
-        {:account_number, "account_number", &DataSchemaTest.to_stringg/1,
-         [optional?: false, empty_values: ["", nil, :undefined]]},
+          {:account_number, "account_number", &DataSchemaTest.to_stringg/1,
+           [optional?: false, empty_values: ["", nil, :undefined]]}
       )
     end
 

--- a/test/data_schema_xml_test.exs
+++ b/test/data_schema_xml_test.exs
@@ -151,7 +151,9 @@ defmodule DataSchemaXmlTest do
           salads: %DataSchema.Errors{
             errors: [
               cheese_slices: %DataSchema.Errors{
-                errors: [mouldy?: "Field was marked as not null but was found to be null."]
+                errors: [
+                  mouldy?: "Field was required but value supplied is considered empty"
+                ]
               }
             ]
           }

--- a/test/field_test.exs
+++ b/test/field_test.exs
@@ -17,7 +17,9 @@ defmodule DataSchema.FieldTest do
       assert DataSchema.to_struct(input, FieldErr) ==
                {:error,
                 %DataSchema.Errors{
-                  errors: [foo: "Field was marked as not null but was found to be null."]
+                  errors: [
+                    foo: "Field was required but value supplied is considered empty"
+                  ]
                 }}
 
       input = %{}
@@ -25,7 +27,9 @@ defmodule DataSchema.FieldTest do
       assert DataSchema.to_struct(input, FieldErr) ==
                {:error,
                 %DataSchema.Errors{
-                  errors: [foo: "Field was marked as not null but was found to be null."]
+                  errors: [
+                    foo: "Field was required but value supplied is considered empty"
+                  ]
                 }}
     end
 
@@ -47,7 +51,9 @@ defmodule DataSchema.FieldTest do
                 %DataSchema.Errors{
                   errors: [
                     agg: %DataSchema.Errors{
-                      errors: [foo: "Field was marked as not null but was found to be null."]
+                      errors: [
+                        foo: "Field was required but value supplied is considered empty"
+                      ]
                     }
                   ]
                 }}


### PR DESCRIPTION
## What's here?

- A new opt is added along with `:optional?` which allows us to declare what kind of values are considered to be empty
- Let's take into consideration the following declaration example:

```ex
defmodule Wallet do
  import DataSchema, only: [data_schema: 1]

  data_schema(
    field:
    {:account_number, "account_number", &DataSchemaTest.to_stringg/1,
     [optional?: false, empty_values: ["", nil, :undefined]]},
  )
end
```

Declaring Wallets with an account number, among any of `["", nil, :undefined]` will cause an error.

```exs
iex(1)> DataSchema.to_struct(%{account_number: :undefined}, Wallet)
 {:error,
  %DataSchema.Errors{
    errors: [
      account_number: "Field was marked as not null but was found to be null."
    ]
  }}
```

## Rundown of changes

- The preprocessor of `DataSchema.to_struct/5` now takes all the opts (as keywords) and transforms them to a map. Sensible defaults are provided when some opts are not provided. This enforces matches in the private functions that process the fields.

- Elixir is updated to 1.13 (I cannot make it run with the current version for some reason)

- Some conditionals have been flattened

- A new error for required empty values has been added
