### PR TITLE
Adds an option to provide default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ struct with `DataSchema.to_struct/2` returning an error if the required field is
 given field. If either the value returned from the data accessor or the casted value are
 equivalent to any element in this list, that field is deemed to be empty. Defaults to `[nil]`,
 meaning nil is always considered "empty".
+* `:default` - specifies a 0 arity function that will be called to produce a default value for a field
+when casting. This function will only be called if a field is found to be empty AND optional.
+If it's empty and not optional we will error.
 
 For example:
 
@@ -60,6 +63,25 @@ For example:
         field: {:type, "the_type", &{:ok, String.upcase(&1)}, optional?: true, empty_values: [nil]},
       ])
     end
+
+  And:
+      defmodule Sandwich do
+        require DataSchema
+
+        DataSchema.data_schema([
+          field: {:list, "list", &{:ok, &1}, optional?: true, empty_values: [[]]},
+        ])
+      end
+
+  And:
+
+      defmodule Sandwich do
+        require DataSchema
+        @options [optional?: true, empty_values: [nil], default: &DateTime.utc_now/0]
+        DataSchema.data_schema([
+          field: {:created_at, "inserted_at", &{:ok, &1}, @options},
+        ])
+      end
 
 To see this better let's look at a very simple example. Assume our input data looks like this:
 

--- a/lib/data_schema.ex
+++ b/lib/data_schema.ex
@@ -82,7 +82,9 @@ defmodule DataSchema do
     - `:empty_values` - allows you to define what values should be used as "empty" for a
     given field. If either the value returned from the data accessor or the casted value are
     equivalent to any element in this list, that field is deemed to be empty. Defaults to `[nil]`.
-
+    - `:default` - specifies a 0 arity function that will be called to produce a default value for a field
+    when casting. This function will only be called if a field is found to be empty AND optional.
+    If it's empty and not optional we will error.
 
   For example:
       defmodule Sandwich do
@@ -102,6 +104,15 @@ defmodule DataSchema do
         ])
       end
 
+  And:
+
+      defmodule Sandwich do
+        require DataSchema
+        @options [optional?: true, empty_values: [nil], default: &DateTime.utc_now/0]
+        DataSchema.data_schema([
+          field: {:created_at, "inserted_at", &{:ok, &1}, @options},
+        ])
+      end
 
   ### Examples
 

--- a/test/default_value_option_test.exs
+++ b/test/default_value_option_test.exs
@@ -1,0 +1,82 @@
+defmodule DefaultValueOptionTest do
+  use ExUnit.Case, async: true
+
+  describe "default_value" do
+    test "default value is used if a field is optional and empty." do
+      schema = [
+        field:
+          {:a, "a", &{:ok, &1},
+           empty_values: [nil], default: fn -> :not_there end, optional?: true}
+      ]
+
+      input = %{}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{a: :not_there}}
+    end
+
+    test "default value is used for list_of when optional and empty" do
+      schema = [
+        list_of:
+          {:a, "a", &{:ok, &1},
+           empty_values: [nil], default: fn -> :not_there end, optional?: true}
+      ]
+
+      input = %{}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{a: :not_there}}
+    end
+
+    test "default value is used for has_many when optional and empty" do
+      schema = [
+        has_many:
+          {:a, "a", {%{}, [field: {:b, "b", &{:ok, &1}}]},
+           empty_values: [nil], default: fn -> :not_there end, optional?: true}
+      ]
+
+      input = %{}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{a: :not_there}}
+    end
+
+    test "default value is used for has_one when optional and empty" do
+      schema = [
+        has_one:
+          {:a, "a", {%{}, [field: {:b, "b", &{:ok, &1}}]},
+           empty_values: [nil], default: fn -> :not_there end, optional?: true}
+      ]
+
+      input = %{}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{a: :not_there}}
+    end
+
+    test "default value is used for aggregate when optional and empty" do
+      # Aggregates are a bit weird because the "empty" value is never null...
+      # I guess it should only respect the fields but technically you can provide
+      # the same options to it so like you could have an "empty" value of %{a: nil, b: nil}
+      # and the aggregate function wont be called.
+      schema = [
+        aggregate:
+          {:agg, [field: {:a, "b", &{:ok, &1}, optional?: true}], &{:ok, &1},
+           empty_values: [%{a: nil}], default: fn -> :not_there end, optional?: true}
+      ]
+
+      input = %{}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{agg: :not_there}}
+
+      # This is when the field we are aggregating is empty, then we
+      aggregates = [
+        field:
+          {:a, "b", &{:ok, &1},
+           empty_values: [nil], default: fn -> :not_there end, optional?: true}
+      ]
+
+      schema = [aggregate: {:agg, aggregates, &{:ok, &1}}]
+
+      input = %{}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{agg: %{a: :not_there}}}
+    end
+  end
+end

--- a/test/default_value_option_test.exs
+++ b/test/default_value_option_test.exs
@@ -78,5 +78,17 @@ defmodule DefaultValueOptionTest do
       result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
       assert result == {:ok, %{agg: %{a: :not_there}}}
     end
+
+    test "when cast fn returns an empty value we use the default" do
+      schema = [
+        field:
+          {:a, "a", fn "not empty" -> {:ok, nil} end,
+           empty_values: [nil], default: fn -> :not_there end, optional?: true}
+      ]
+
+      input = %{"a" => "not empty"}
+      result = DataSchema.to_struct(input, %{}, schema, DataSchema.MapAccessor)
+      assert result == {:ok, %{a: :not_there}}
+    end
   end
 end


### PR DESCRIPTION
This option lets you specify a fn which will be called if a field is found to be empty. If it's allowed to be empty the output of that function will be set as the field's value. If it's not it will error.