### PR TITLE
Captures raises in casting functions and re-raises

### DIFF
--- a/lib/cast_function_error.ex
+++ b/lib/cast_function_error.ex
@@ -1,0 +1,6 @@
+defmodule DataSchema.CastFunctionError do
+  @moduledoc """
+  An error for when a casting function does not return the correct data.
+  """
+  defexception [:message]
+end

--- a/lib/cast_function_error.ex
+++ b/lib/cast_function_error.ex
@@ -1,6 +1,124 @@
 defmodule DataSchema.CastFunctionError do
   @moduledoc """
   An error for when a casting function does not return the correct data.
+
+  All casting functions get wrapped  in a `rescue` to catch any unexpected exceptions. This
+  lets us add more useful information about where the error occurred that the stack trace
+  cannot provide - mainly which field failed the casting.
+
+  We then raise using the original stacktrace and printing the captured error message.
+
+  ### Matching on Specific Exceptions
+
+  If a user wishes to capture specific exceptions as part of casting they may do so by
+  matching on the `:wrapped_error` field. For example:
+
+      try do
+        DataSchema.to_struct(my_input, MySchema)
+      rescue
+        %DataSchema.CastFunctionError{wrapped_error: %RuntimeError{}} ->
+          Logger.error("Expected Runtime Error")
+        error ->
+          reraise error, __STACKTRACE__
+      end
   """
-  defexception [:message]
+  defexception [
+    :message,
+    :casted_value,
+    :leaf_field,
+    :path,
+    :wrapped_error,
+    :stacktrace_of_wrapped_error
+  ]
+
+  @doc """
+  Creates an appropriate error message from the given struct.
+  """
+  def error_message(%__MODULE__{
+        casted_value: value,
+        path: path,
+        leaf_field: leaf_field,
+        wrapped_error: wrapped_error
+      }) do
+    """
+
+
+    Unexpected error when casting value #{inspect(value)}
+    #{field_message(path, leaf_field)}
+    Full path to field was:
+
+    #{inspect_path(path)}
+    The casting function raised the following error:
+
+    #{Exception.format(:error, wrapped_error)}
+    """
+  end
+
+  defp field_message(path, leaf_field) do
+    case List.last(path) do
+      {schema, field} when is_atom(field) ->
+        """
+        for field #{inspect(field)} in schema #{inspect(schema)}
+        """
+
+      field when is_atom(field) ->
+        """
+        for field #{inspect(field)} in this part of the schema:
+
+        #{formatted_field(leaf_field)}
+        """
+    end
+  end
+
+  defp inspect_path(path) do
+    [first | rest] = path |> Enum.reverse()
+
+    rest
+    |> Enum.reduce("      #{node_to_string(first)}", fn field, acc ->
+      acc <> "Under " <> node_to_string(field)
+    end)
+  end
+
+  defp node_to_string({module, field}) do
+    "Field  #{inspect(field)} in #{inspect(module)}\n"
+  end
+
+  defp node_to_string(field) do
+    "Field  #{inspect(field)}\n"
+  end
+
+  # What happens with aggregate?
+  defp formatted_field({:field, rest}) do
+    "field: #{inspect(rest)},"
+  end
+
+  defp formatted_field({:has_one, rest}) do
+    "has_one: #{inspect(rest)},"
+  end
+
+  defp formatted_field({:has_many, rest}) do
+    "has_many: #{inspect(rest)},"
+  end
+
+  defp formatted_field({:list_of, rest}) do
+    "list_of: #{inspect(rest)},"
+  end
+
+  defp formatted_field({:aggregate, {field, path, cast, opts}}) do
+    """
+    @aggregate_fields [
+      #{Enum.map_join(path, "\n  ", &formatted_field/1)}
+    ]
+    aggregate: {#{inspect(field)}, @aggregate_fields, #{inspect(cast)}, #{inspect(opts)}},
+    """
+  end
+
+  defp formatted_field({:aggregate, {field, path, cast}}) do
+    """
+    @aggregate_fields [
+      #{Enum.map_join(path, "\n  ", &formatted_field/1)}
+    ]
+    aggregate: {#{inspect(field)}, @aggregate_fields, #{inspect(cast)}},
+    """
+  end
 end

--- a/test/cast_function_error_test.exs
+++ b/test/cast_function_error_test.exs
@@ -1,0 +1,111 @@
+defmodule DataSchema.CastFunctionErrorTest do
+  use ExUnit.Case, async: true
+  alias DataSchema.CastFunctionError
+
+  describe "error_message/1" do
+    test "when path has no modules in it (ie runtime schema)" do
+      error = %DataSchema.CastFunctionError{
+        casted_value: "borked",
+        # There are a lot of permutations here...
+        leaf_field: {:field, {:a, "a", StringType}},
+        path: [:a, :b, :c],
+        wrapped_error: %RuntimeError{},
+        stacktrace_of_wrapped_error: dummy_stacktrace()
+      }
+
+      message = CastFunctionError.error_message(error)
+
+      assert message == """
+
+
+             Unexpected error when casting value "borked"
+             for field :c in this part of the schema:
+
+             field: {:a, "a", StringType},
+
+             Full path to field was:
+
+                   Field  :c
+             Under Field  :b
+             Under Field  :a
+
+             The casting function raised the following error:
+
+             ** (RuntimeError) runtime error
+             """
+    end
+
+    test "compile time schemas" do
+      error = %DataSchema.CastFunctionError{
+        casted_value: "borked",
+        # There are a lot of permutations here...
+        leaf_field: {:field, {:a, "a", StringType}},
+        path: [{ASchema, :a}, {BSchema, :b}, {CSchema, :c}],
+        wrapped_error: %RuntimeError{},
+        stacktrace_of_wrapped_error: dummy_stacktrace()
+      }
+
+      message = CastFunctionError.error_message(error)
+
+      assert message == """
+
+
+             Unexpected error when casting value "borked"
+             for field :c in schema CSchema
+
+             Full path to field was:
+
+                   Field  :c in CSchema
+             Under Field  :b in BSchema
+             Under Field  :a in ASchema
+
+             The casting function raised the following error:
+
+             ** (RuntimeError) runtime error
+             """
+    end
+
+    test "mix of runtime and compile time schemas - aggregate" do
+      error = %DataSchema.CastFunctionError{
+        casted_value: "borked",
+        leaf_field: {:aggregate, {:post_datetime, [field: {:a, "a", StringType}], AggType}},
+        path: [:a, {BSchema, :b}, :c],
+        wrapped_error: %RuntimeError{},
+        stacktrace_of_wrapped_error: dummy_stacktrace()
+      }
+
+      message = CastFunctionError.error_message(error)
+
+      assert message == """
+
+
+             Unexpected error when casting value "borked"
+             for field :c in this part of the schema:
+
+             @aggregate_fields [
+               field: {:a, "a", StringType},
+             ]
+             aggregate: {:post_datetime, @aggregate_fields, AggType},
+
+
+             Full path to field was:
+
+                   Field  :c
+             Under Field  :b in BSchema
+             Under Field  :a
+
+             The casting function raised the following error:
+
+             ** (RuntimeError) runtime error
+             """
+    end
+  end
+
+  defp dummy_stacktrace() do
+    [
+      {DataSchema.String, :cast, 1,
+       [file: 'test/support/string.ex', line: 9, error_info: %{module: Exception}]},
+      {DataSchema, :call_cast_fn, 3, [file: 'lib/data_schema.ex', line: 1082]}
+    ]
+  end
+end

--- a/test/data_schema_map_test.exs
+++ b/test/data_schema_map_test.exs
@@ -19,7 +19,13 @@ defmodule DataSchemaMapTest do
       import DataSchema, only: [data_schema: 1]
 
       data_schema(
-        field: {:date, "date", &Date.from_iso8601/1},
+        field:
+          {:date, "date",
+           fn
+             "raise agg" -> {:ok, "raise agg"}
+             "raise" -> raise "no m8"
+             x -> Date.from_iso8601(x)
+           end},
         field: {:time, "time", &Time.from_iso8601/1}
       )
     end
@@ -35,6 +41,10 @@ defmodule DataSchemaMapTest do
       has_one: {:draft, "draft", DraftPost},
       aggregate: {:post_datetime, DateTime, &BlogPost.to_datetime/1}
     )
+
+    def to_datetime(%{date: "raise agg"}) do
+      raise "NoOPE"
+    end
 
     def to_datetime(%{date: date, time: time}) do
       NaiveDateTime.new(date, time)
@@ -105,7 +115,7 @@ defmodule DataSchemaMapTest do
       assert blog.draft == %DataSchemaMapTest.DraftPost{content: "This is a draft blog post"}
     end
 
-    test "when a cast fn raises we capture that and re-raise" do
+    test "when a field cast fn raises we capture that and re-raise" do
       source_data = %{
         "content" => "raise",
         "comments" => [%{"text" => "This is a comment"}, %{"text" => "This is another comment"}],
@@ -116,24 +126,273 @@ defmodule DataSchemaMapTest do
       }
 
       message = """
-      \n  ** (RuntimeError)
 
-      Error when casting field:
 
-        field: {:content, "content", #Function<0.80199311/1 in DataSchemaMapTest.BlogPost.__data_schema_fields/0>},
+      Unexpected error when casting value "raise"
+      for field :content in schema DataSchemaMapTest.BlogPost
+
+      Full path to field was:
+
+            Field  :content in DataSchemaMapTest.BlogPost
 
       The casting function raised the following error:
 
-        RuntimeError
-
-      with message:
-
-        "nope"
-
+      ** (RuntimeError) nope
       """
 
       assert_raise(DataSchema.CastFunctionError, message, fn ->
         DataSchema.to_struct(source_data, BlogPost)
+      end)
+    end
+
+    test "when a field on a has_one cast fn raises we capture that and re-raise" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => [%{"text" => "This is a comment"}, %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "raise"},
+        "date" => "2021-11-11",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      message = """
+
+
+      Unexpected error when casting value "raise"
+      for field :content in schema DataSchemaMapTest.DraftPost
+
+      Full path to field was:
+
+            Field  :content in DataSchemaMapTest.DraftPost
+      Under Field  :draft in DataSchemaMapTest.BlogPost
+
+      The casting function raised the following error:
+
+      ** (RuntimeError) Nope!
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, BlogPost)
+      end)
+    end
+
+    test "when a field on a has_many cast fn raises we capture that and re-raise" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => [%{"text" => "raise"}, %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "ssssssssss"},
+        "date" => "2022-01-01",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      message = """
+
+
+      Unexpected error when casting value "raise"
+      for field :text in schema DataSchemaMapTest.Comment
+
+      Full path to field was:
+
+            Field  :text in DataSchemaMapTest.Comment
+      Under Field  :comments in DataSchemaMapTest.BlogPost
+
+      The casting function raised the following error:
+
+      ** (RuntimeError) Nope!
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, BlogPost)
+      end)
+    end
+
+    test "when the aggregate cast fn raises in a runtime schema" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => [%{"text" => "raised right"}, %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "ssssssssss"},
+        "date" => "raise agg",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      schema = [
+        aggregate:
+          {:post_datetime,
+           [
+             field: {:date, "date", DataSchema.DateCast},
+             field: {:time, "time", DataSchema.TimeCast}
+           ], &DataSchemaMapTest.BlogPost.to_datetime/1}
+      ]
+
+      message = """
+
+
+      Unexpected error when casting value %{date: "raise agg", time: ~T[14:00:00]}
+      for field :post_datetime in this part of the schema:
+
+      @aggregate_fields [
+        field: {:date, "date", DataSchema.DateCast},
+        field: {:time, "time", DataSchema.TimeCast},
+      ]
+      aggregate: {:post_datetime, @aggregate_fields, &DataSchemaMapTest.BlogPost.to_datetime/1},
+
+
+      Full path to field was:
+
+            Field  :post_datetime
+
+      The casting function raised the following error:
+
+      ** (RuntimeError) NoOPE
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, %{}, schema, DataSchema.MapAccessor)
+      end)
+    end
+
+    test "when the aggregate has an aggregate and cast fn raises in a runtime schema" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => [%{"text" => "raised right"}, %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "ssssssssss"},
+        "date" => "2022-01-01",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      agg_fields = [
+        aggregate: {:test, [field: {:date, "date", DataSchema.DateCast}], AggType},
+        field: {:time, "time", DataSchema.TimeCast}
+      ]
+
+      schema = [
+        aggregate: {:post_datetime, agg_fields, &DataSchemaMapTest.BlogPost.to_datetime/1}
+      ]
+
+      message = """
+
+
+      Unexpected error when casting value %{date: ~D[2022-01-01]}
+      for field :test in this part of the schema:
+
+      @aggregate_fields [
+        field: {:date, "date", DataSchema.DateCast},
+      ]
+      aggregate: {:test, @aggregate_fields, AggType},
+
+
+      Full path to field was:
+
+            Field  :test
+      Under Field  :post_datetime
+
+      The casting function raised the following error:
+
+      ** (UndefinedFunctionError) function AggType.cast/1 is undefined (module AggType is not available)
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, %{}, schema, DataSchema.MapAccessor)
+      end)
+    end
+
+    test "when the aggregate cast fn raises" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => [%{"text" => "raised right"}, %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "ssssssssss"},
+        "date" => "raise agg",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      message = """
+
+
+      Unexpected error when casting value %DataSchemaMapTest.BlogPost.DateTime{date: "raise agg", time: ~T[14:00:00]}
+      for field :post_datetime in schema DataSchemaMapTest.BlogPost
+
+      Full path to field was:
+
+            Field  :post_datetime in DataSchemaMapTest.BlogPost
+
+      The casting function raised the following error:
+
+      ** (RuntimeError) NoOPE
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, BlogPost)
+      end)
+    end
+
+    test "when an aggregate field raises" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => [%{"text" => "raised right"}, %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "ssssssssss"},
+        "date" => "raise",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      message = """
+
+
+      Unexpected error when casting value "raise"
+      for field :date in schema DataSchemaMapTest.BlogPost.DateTime
+
+      Full path to field was:
+
+            Field  :date in DataSchemaMapTest.BlogPost.DateTime
+      Under Field  :post_datetime in DataSchemaMapTest.BlogPost
+
+      The casting function raised the following error:
+
+      ** (RuntimeError) no m8
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, BlogPost)
+      end)
+    end
+
+    test "when a field on a list_of cast fn raises we capture that and re-raise" do
+      source_data = %{
+        "content" => "one upon a time",
+        "comments" => ["raise", %{"text" => "This is another comment"}],
+        "draft" => %{"content" => "ssssssssss"},
+        "date" => "2022-01-01",
+        "time" => "14:00:00",
+        "metadata" => %{"rating" => 0}
+      }
+
+      schema = [
+        list_of: {:comments, "comments", DataSchema.RaiseString}
+      ]
+
+      message = """
+
+
+      Unexpected error when casting value "raise"
+      for field :comments in this part of the schema:
+
+      list_of: {:comments, "comments", DataSchema.RaiseString},
+
+      Full path to field was:
+
+            Field  :comments
+
+      The casting function raised the following error:
+
+      ** (RuntimeError) no m8
+      """
+
+      assert_raise(DataSchema.CastFunctionError, message, fn ->
+        DataSchema.to_struct(source_data, %{}, schema, DataSchema.MapAccessor)
       end)
     end
   end

--- a/test/support/date_cast.ex
+++ b/test/support/date_cast.ex
@@ -1,0 +1,16 @@
+defmodule DataSchema.DateCast do
+  @moduledoc """
+  Used for testing only
+  """
+  def cast("raise agg"), do: {:ok, "raise agg"}
+  def cast("raise"), do: raise("no m8")
+  def cast(x), do: Date.from_iso8601(x)
+end
+
+defmodule DataSchema.RaiseString do
+  @moduledoc """
+  Used for testing only
+  """
+  def cast("raise"), do: raise("no m8")
+  def cast(x), do: {:ok, x}
+end

--- a/test/support/string.ex
+++ b/test/support/string.ex
@@ -5,7 +5,10 @@ defmodule DataSchema.String do
   @behaviour DataSchema.CastBehaviour
 
   @impl true
-  def cast(string) when is_binary(string), do: {:ok, string}
+  def cast(string) when is_binary(string) do
+    {:ok, string}
+  end
+
   @impl true
   def cast(string), do: {:ok, to_string(string)}
 end

--- a/test/support/string.ex
+++ b/test/support/string.ex
@@ -5,6 +5,10 @@ defmodule DataSchema.String do
   @behaviour DataSchema.CastBehaviour
 
   @impl true
+  def cast("raise") do
+    raise "Nope!"
+  end
+
   def cast(string) when is_binary(string) do
     {:ok, string}
   end

--- a/test/support/time_cast.ex
+++ b/test/support/time_cast.ex
@@ -1,0 +1,6 @@
+defmodule DataSchema.TimeCast do
+  @moduledoc """
+  Used for testing only
+  """
+  def cast(x), do: Time.from_iso8601(x)
+end


### PR DESCRIPTION
Problem: when a casting function raises unexpectedly it can be hard to see which field was blowing up. The stack trace doesn't help because often cast fns are modules that implement a cast function.

This commit wraps a try / catch around all cast fns and if the function unexpectedly fails we raise a DataSchema error that includes enough information to be able to see which field it was that caused problems.

There are basically 3 things we could have done:

1. use macros for fields and then try to engineer better stack traces by having the cast fn actually call in a specific module (the place where the schema is defined).
2. Catch the original error and re-raise it but pre/append onto the error the extra information that will let the user know which field failed.
3. Raise our own error with the information from the one we captured inside it.

The problem with 1. is it massively changes how the library works and it doesn't even necessarily work for runtime schemas which can be generated on the fly. I like how the schemas are just lists of data and introducing a macro hides what they really are. This gives us the ability to hide details but as the user of the lib I probably don't want that.

2. is a bit weird and unexpected probably, so we went for 3.

I kind of don't like that we capture all exceptions and wrap them but I think it's okay. Users can match on the struct field to match on the specific exception if they want to catch it.

```elixir
try do
  DataSchema.to_struct(my_input, MySchema)
rescue
  %DataSchema.CastFunctionError{wrapped_error: %RuntimeError{}} ->
    Logger.error("Expected Runtime Error")
  error ->
    reraise error, __STACKTRACE__
end
```