### PR TITLE
remove `:source_ref` from ExDoc config option to avoid broken links to github sources

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,6 @@ defmodule DataSchema.MixProject do
   defp docs do
     [
       main: DataSchema,
-      source_ref: "v#{@version}",
       extra_section: "GUIDES",
       source_url: @source_url,
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],


### PR DESCRIPTION
Just a small thing I noticed.

Consider removing the `:source_ref` [configuration option](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-configuration) from the ExDoc configuration. Right now ExDoc renders invalid urls to github. When not set, it will render links to the `main` branch, which works as expected (without the version in the url path).
I don't think it breaks anyhthing else.

Ignore if not appropriate.